### PR TITLE
Remind urls_to_html will print HTML tags in input string

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ Use `urls_to_html` filter in your templates:
 {# output: Basic example <a href="http://example.com">http://example.com</a> #}
 ```
 
-To properly handle HTML entity escaped string, use [Encoder](https://github.com/vstelmakh/url-highlight#encoder).  
-See configuration example below.
+To properly handle HTML entity escaped string, use [Encoder](https://github.com/vstelmakh/url-highlight#encoder). See configuration example below.
+
+**Warning: the filter considers the input string being already safe, and it will print any HTML tag in it. It is the developer's responsability to sanitise the input before passing it to `urls_to_html`.**
 
 ## Configuration
 Additional options could be provided via UrlHighlight constructor. For more details see: Url highlight [configuration](https://github.com/vstelmakh/url-highlight#configuration).


### PR DESCRIPTION
Update README.md file with a warning to remind developers to sanitise data before passing it to urls_to_html filter.

See https://github.com/vstelmakh/url-highlight-twig-extension/issues/10